### PR TITLE
Add Livewire plugin and persistent cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Choso Digital Marketplace
+
+This project is a multi‑seller platform for digital products built with **Laravel**, **Livewire** and **Tailwind CSS**.  It provides buyer, seller and admin flows inspired by sites like Gumroad and Plati.market but customised for the Vietnamese market.
+
+## Features
+
+- Buyer, Seller and Admin user roles
+- Product, Category, Order and Wallet management
+- Livewire components for browsing products, viewing details and managing the cart
+- Seller dashboard
+- Choso brand theme colours
+
+## Setup on Codex
+
+1. If PHP is not installed, add it with:
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y php php-cli php-mbstring php-xml
+   ```
+2. Install PHP and Node dependencies:
+   ```bash
+   composer install
+   npm install
+   ```
+3. Copy the environment file and generate the application key:
+   ```bash
+   cp .env.example .env
+   php artisan key:generate
+   ```
+4. Run the database migrations:
+   ```bash
+   php artisan migrate
+   ```
+5. Build frontend assets:
+   ```bash
+   npm run build
+   ```
+6. Start the development server:
+   ```bash
+   php artisan serve
+   ```
+
+Automated tests can be run with:
+```bash
+php vendor/bin/phpunit
+```

--- a/app/Http/Middleware/SellerOnly.php
+++ b/app/Http/Middleware/SellerOnly.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SellerOnly
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->user() || $request->user()->role !== User::ROLE_SELLER) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Livewire/Seller/Dashboard.php
+++ b/app/Livewire/Seller/Dashboard.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Livewire\Seller;
+
+use App\Models\Product;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('components.layouts.market')]
+class Dashboard extends Component
+{
+    public function render()
+    {
+        $products = Product::where('user_id', Auth::id())->get();
+
+        return view('seller.dashboard', [
+            'products' => $products,
+        ]);
+    }
+}

--- a/app/Livewire/Shop/Cart.php
+++ b/app/Livewire/Shop/Cart.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Livewire\Shop;
+
+use App\Models\Product;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+#[Layout('components.layouts.market')]
+class Cart extends Component
+{
+    public array $items = [];
+
+    #[On('add-to-cart')]
+    public function add(int $productId)
+    {
+        $product = Product::findOrFail($productId);
+        $this->items[$productId] = [
+            'product' => $product,
+            'quantity' => ($this->items[$productId]['quantity'] ?? 0) + 1,
+        ];
+    }
+
+    public function remove(int $productId)
+    {
+        unset($this->items[$productId]);
+    }
+
+    public function render()
+    {
+        return view('shop.cart');
+    }
+}

--- a/app/Livewire/Shop/Index.php
+++ b/app/Livewire/Shop/Index.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Livewire\Shop;
+
+use App\Models\Product;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('components.layouts.market')]
+class Index extends Component
+{
+    public function render()
+    {
+        $products = Product::latest()->get();
+
+        return view('shop.index', [
+            'products' => $products,
+        ]);
+    }
+}

--- a/app/Livewire/Shop/Show.php
+++ b/app/Livewire/Shop/Show.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Livewire\Shop;
+
+use App\Models\Product;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('components.layouts.market')]
+class Show extends Component
+{
+    public Product $product;
+
+    public function mount(Product $product)
+    {
+        $this->product = $product;
+    }
+
+    public function render()
+    {
+        return view('shop.show');
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'slug',
+    ];
+
+    public function products()
+    {
+        return $this->hasMany(Product::class);
+    }
+}

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Order extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'product_id',
+        'amount',
+        'status',
+    ];
+
+    public function buyer()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'category_id',
+        'name',
+        'slug',
+        'price',
+        'description',
+        'file_path',
+    ];
+
+    public function seller()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,11 +7,24 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Str;
+use App\Models\Product;
+use App\Models\Wallet;
+use App\Models\Order;
 
 class User extends Authenticatable
 {
+    public const ROLE_BUYER = 'buyer';
+    public const ROLE_SELLER = 'seller';
+    public const ROLE_ADMIN = 'admin';
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, Notifiable;
+
+    protected static function booted(): void
+    {
+        static::created(function (User $user): void {
+            $user->wallet()->create(['balance' => 0]);
+        });
+    }
 
     /**
      * The attributes that are mass assignable.
@@ -22,6 +35,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**
@@ -57,5 +71,20 @@ class User extends Authenticatable
             ->take(2)
             ->map(fn ($word) => Str::substr($word, 0, 1))
             ->implode('');
+    }
+
+    public function products()
+    {
+        return $this->hasMany(Product::class);
+    }
+
+    public function wallet()
+    {
+        return $this->hasOne(Wallet::class);
+    }
+
+    public function orders()
+    {
+        return $this->hasMany(Order::class);
     }
 }

--- a/app/Models/Wallet.php
+++ b/app/Models/Wallet.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Wallet extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'balance',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'seller' => \App\Http\Middleware\SellerOnly::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,6 +28,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'role' => 'buyer',
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->string('role')->default('buyer');
             $table->rememberToken();
             $table->timestamps();
         });

--- a/database/migrations/2024_01_01_000003_create_categories_table.php
+++ b/database/migrations/2024_01_01_000003_create_categories_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2024_01_01_000004_create_products_table.php
+++ b/database/migrations/2024_01_01_000004_create_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('category_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->decimal('price', 12, 2);
+            $table->text('description')->nullable();
+            $table->string('file_path');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/database/migrations/2024_01_01_000005_create_orders_table.php
+++ b/database/migrations/2024_01_01_000005_create_orders_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->decimal('amount', 12, 2);
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/database/migrations/2024_01_01_000006_create_wallets_table.php
+++ b/database/migrations/2024_01_01_000006_create_wallets_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('wallets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->decimal('balance', 12, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('wallets');
+    }
+};

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -8,7 +8,15 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-    --font-sans: 'Instrument Sans', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+    --font-sans: 'Inter', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+
+    --color-primary: #00796B;
+    --color-secondary: #E0F2F1;
+    --color-dark: #111827;
+    --color-gray: #374151;
+    --color-accent: #FFD54F;
+    --color-info: #4FC3F7;
+    --color-danger: #EF5350;
 
     --color-zinc-50: #fafafa;
     --color-zinc-100: #f5f5f5;
@@ -22,7 +30,6 @@
     --color-zinc-900: #171717;
     --color-zinc-950: #0a0a0a;
 
-    --color-accent: var(--color-neutral-800);
     --color-accent-content: var(--color-neutral-800);
     --color-accent-foreground: var(--color-white);
 }

--- a/resources/views/components/layouts/market.blade.php
+++ b/resources/views/components/layouts/market.blade.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+    <head>
+        @include('partials.head')
+    </head>
+    <body class="min-h-screen bg-[#111827] text-white">
+        <header class="bg-[#00796B] p-4 flex justify-between items-center">
+            <a href="{{ route('home') }}" class="font-bold" wire:navigate>Choso</a>
+            <nav class="flex gap-4">
+                @auth
+                    <a href="{{ route('seller.dashboard') }}" wire:navigate>Seller Dashboard</a>
+                    <a href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">Logout</a>
+                    <form id="logout-form" method="POST" action="{{ route('logout') }}" class="hidden">@csrf</form>
+                @else
+                    <a href="{{ route('login') }}" wire:navigate>Login</a>
+                @endauth
+            </nav>
+        </header>
+        <main class="p-6">
+            {{ $slot }}
+        </main>
+        <aside class="fixed top-16 right-0 w-64 h-full bg-[#111827] border-l border-[#374151] p-4 overflow-y-auto">
+            <livewire:shop.cart />
+        </aside>
+        @fluxScripts
+    </body>
+</html>

--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -8,7 +8,7 @@
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
 <link rel="preconnect" href="https://fonts.bunny.net">
-<link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
+<link href="https://fonts.bunny.net/css?family=inter:400,500,600" rel="stylesheet" />
 
 @vite(['resources/css/app.css', 'resources/js/app.js'])
 @fluxAppearance

--- a/resources/views/seller/dashboard.blade.php
+++ b/resources/views/seller/dashboard.blade.php
@@ -1,0 +1,9 @@
+<div>
+    <h1 class="text-2xl font-semibold mb-4">My Products</h1>
+    <a href="#" class="bg-[#4FC3F7] text-black px-4 py-2 rounded">Add Product</a>
+    <ul class="mt-4 space-y-2">
+        @foreach($products as $product)
+            <li class="border border-[#374151] p-2">{{ $product->name }}</li>
+        @endforeach
+    </ul>
+</div>

--- a/resources/views/shop/cart.blade.php
+++ b/resources/views/shop/cart.blade.php
@@ -1,0 +1,11 @@
+<div>
+    <h1 class="text-xl font-semibold mb-4">Your Cart</h1>
+    <ul>
+        @foreach($items as $item)
+            <li class="flex justify-between mb-2">
+                <span>{{ $item['product']->name }} x {{ $item['quantity'] }}</span>
+                <button wire:click="remove({{ $item['product']->id }})" class="text-[#EF5350]">Remove</button>
+            </li>
+        @endforeach
+    </ul>
+</div>

--- a/resources/views/shop/index.blade.php
+++ b/resources/views/shop/index.blade.php
@@ -1,0 +1,8 @@
+<div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    @foreach($products as $product)
+        <a href="{{ route('shop.show', $product) }}" class="border border-[#374151] rounded p-4" wire:navigate>
+            <h2 class="font-semibold text-lg">{{ $product->name }}</h2>
+            <p class="text-[#4FC3F7]">{{ number_format($product->price) }} Scoin</p>
+        </a>
+    @endforeach
+</div>

--- a/resources/views/shop/show.blade.php
+++ b/resources/views/shop/show.blade.php
@@ -1,0 +1,6 @@
+<div class="max-w-2xl mx-auto space-y-4">
+    <h1 class="text-2xl font-semibold">{{ $product->name }}</h1>
+    <p>{{ $product->description }}</p>
+    <p class="text-[#FFD54F] font-semibold">{{ number_format($product->price) }} Scoin</p>
+    <button wire:click="dispatch('add-to-cart', id: $product->id)" class="bg-[#00796B] text-white px-4 py-2 rounded">Add to Cart</button>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,15 +3,25 @@
 use App\Livewire\Settings\Appearance;
 use App\Livewire\Settings\Password;
 use App\Livewire\Settings\Profile;
+use App\Livewire\Shop\Index as ShopIndex;
+use App\Livewire\Shop\Show as ShopShow;
+use App\Livewire\Shop\Cart as ShopCart;
+use App\Livewire\Seller\Dashboard as SellerDashboard;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/', function () {
-    return view('welcome');
-})->name('home');
+Route::get('/', ShopIndex::class)->name('home');
 
 Route::view('dashboard', 'dashboard')
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
+
+Route::get('/products', ShopIndex::class)->name('shop.index');
+Route::get('/products/{product}', ShopShow::class)->name('shop.show');
+Route::get('/cart', ShopCart::class)->name('shop.cart');
+
+Route::middleware(['auth', 'seller'])->group(function () {
+    Route::get('/seller', SellerDashboard::class)->name('seller.dashboard');
+});
 
 Route::middleware(['auth'])->group(function () {
     Route::redirect('settings', 'settings/profile');

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import {
 } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import tailwindcss from "@tailwindcss/vite";
+import livewire from '@defstudio/vite-livewire-plugin';
 
 export default defineConfig({
     plugins: [
@@ -11,6 +12,7 @@ export default defineConfig({
             refresh: true,
         }),
         tailwindcss(),
+        livewire(),
     ],
     server: {
         cors: true,


### PR DESCRIPTION
## Summary
- enable `@defstudio/vite-livewire-plugin` in Vite config
- embed cart component in market layout for persistent sidebar cart
- document PHP installation instructions for Codex environments

## Testing
- `php vendor/bin/phpunit` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ae92a5b50832c8f0165a8d7e222a9