### PR TITLE
Implement basic download limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Uploaded product files are stored in `storage/app/products`. To generate a publi
 
 Uploaded product files are stored in `storage/app/products`. After a purchase, buyers receive links pointing to `/download/{orderItem}`. The route validates ownership and returns the file via `Storage::disk('products')->download()`.
 
+Downloads are limited to **5 times** within **3 days** of the order date. Further requests will be rejected.
+
 
 - Checkout purchases using the built-in Scoin wallet
 - Product files stored in `storage/app/products` and downloadable via `Storage::url($product->file_path)`

--- a/app/Models/DownloadLog.php
+++ b/app/Models/DownloadLog.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DownloadLog extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'order_item_id',
+        'ip_address',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function orderItem()
+    {
+        return $this->belongsTo(OrderItem::class);
+    }
+}

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\DownloadLog;
 
 class OrderItem extends Model
 {
@@ -24,5 +25,10 @@ class OrderItem extends Model
     public function product()
     {
         return $this->belongsTo(Product::class);
+    }
+
+    public function downloadLogs()
+    {
+        return $this->hasMany(DownloadLog::class);
     }
 }

--- a/database/migrations/2024_01_01_000008_create_download_logs_table.php
+++ b/database/migrations/2024_01_01_000008_create_download_logs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('download_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('order_item_id')->constrained()->cascadeOnDelete();
+            $table->string('ip_address', 45)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('download_logs');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,6 +57,19 @@ Route::get('/download/{orderItem}', function (\App\Models\OrderItem $orderItem) 
         abort(403);
     }
 
+    if ($orderItem->downloadLogs()->count() >= 5) {
+        abort(403, 'Download limit reached');
+    }
+
+    if ($orderItem->order->created_at->lt(now()->subDays(3))) {
+        abort(403, 'Download period expired');
+    }
+
+    $orderItem->downloadLogs()->create([
+        'user_id' => $user->id,
+        'ip_address' => request()->ip(),
+    ]);
+
     return \Illuminate\Support\Facades\Storage::disk('products')
         ->download($orderItem->product->file_path);
 })->middleware('auth')->name('download');


### PR DESCRIPTION
## Summary
- add `DownloadLog` model and migration
- log downloads and enforce limits in `/download/{orderItem}` route
- document download policy in README

## Testing
- `php vendor/bin/phpunit --stop-on-failure tests/Unit`


------
https://chatgpt.com/codex/tasks/task_e_684c16022bc0832c9b3fcbe7cbaf0ed2