### PR TITLE
Implement settings helper and model

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1,0 +1,10 @@
+<?php
+
+use App\Models\Setting;
+
+if (! function_exists('setting')) {
+    function setting(string $key, $default = null)
+    {
+        return Setting::where('key', $key)->value('value') ?? $default;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/database/migrations/2024_01_01_000013_create_settings_table.php
+++ b/database/migrations/2024_01_01_000013_create_settings_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};


### PR DESCRIPTION
## Summary
- create `Setting` model and migration
- add global `setting()` helper
- autoload the helper in `composer.json`

## Testing
- `composer dump-autoload`
- `composer test` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d282662708329964cae7ab20f12b5