### PR TITLE
Add admin flag to WalletLog

### DIFF
--- a/app/Models/WalletLog.php
+++ b/app/Models/WalletLog.php
@@ -15,6 +15,16 @@ class WalletLog extends Model
         'type',
         'amount',
         'description',
+        'by_admin',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'by_admin' => 'boolean',
     ];
 
     public function user(): BelongsTo


### PR DESCRIPTION
## Summary
- allow `by_admin` in WalletLog mass assignment
- cast `by_admin` attribute to boolean

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d291c17648329b8672949787b76c3