### PR TITLE
Fix withdrawal approval flow

### DIFF
--- a/app/Livewire/Admin/Withdrawals.php
+++ b/app/Livewire/Admin/Withdrawals.php
@@ -35,13 +35,6 @@ class Withdrawals extends Component
             ]);
         });
 
-        $withdrawal->status = 'approved';
-        $withdrawal->save();
-
-        $user = $withdrawal->user;
-        $user->wallet -= $withdrawal->amount;
-        $user->save();
-
     }
 
     public function reject(Withdrawal $withdrawal): void
@@ -56,10 +49,6 @@ class Withdrawals extends Component
             $withdrawal->note = 'Rejected';
             $withdrawal->save();
         });
-
-        $withdrawal->status = 'rejected';
-        $withdrawal->note = 'Rejected';
-        $withdrawal->save();
 
     }
 


### PR DESCRIPTION
## Summary
- clean up approval flow for withdrawals
- ensure wallet deduction and logging happen only within a single DB transaction

## Testing
- `php vendor/bin/phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684d29a6e8d883299239198dbc144916