### PR TITLE
Implement category management for admin

### DIFF
--- a/app/Livewire/Admin/ManageCategories.php
+++ b/app/Livewire/Admin/ManageCategories.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Livewire\Admin;
+
+use App\Models\Category;
+use Illuminate\Support\Str;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.admin')]
+class ManageCategories extends Component
+{
+    public ?int $editingId = null;
+    public string $name = '';
+
+    protected $rules = [
+        'name' => 'required|string|max:255',
+    ];
+
+    public function save(): void
+    {
+        $this->validate();
+        $slug = Str::slug($this->name);
+
+        if ($this->editingId) {
+            Category::where('id', $this->editingId)->update([
+                'name' => $this->name,
+                'slug' => $slug,
+            ]);
+            session()->flash('status', 'Category updated.');
+        } else {
+            Category::create([
+                'name' => $this->name,
+                'slug' => $slug,
+            ]);
+            session()->flash('status', 'Category created.');
+        }
+
+        $this->reset('name', 'editingId');
+    }
+
+    public function edit(int $id): void
+    {
+        $category = Category::find($id);
+        if ($category) {
+            $this->editingId = $category->id;
+            $this->name = $category->name;
+        }
+    }
+
+    public function delete(int $id): void
+    {
+        Category::where('id', $id)->delete();
+    }
+
+    public function render()
+    {
+        return view('admin.manage-categories', [
+            'categories' => Category::latest()->get(),
+        ]);
+    }
+}

--- a/resources/views/admin/manage-categories.blade.php
+++ b/resources/views/admin/manage-categories.blade.php
@@ -1,0 +1,39 @@
+<div>
+    <h1 class="text-xl font-semibold mb-4">Manage Categories</h1>
+
+    @if(session('status'))
+        <div class="mb-4 text-green-600 dark:text-green-400">{{ session('status') }}</div>
+    @endif
+
+    <form wire:submit.prevent="save" class="mb-4 space-x-2">
+        <input type="text" wire:model="name" placeholder="Name" class="border p-1 rounded" />
+        <button type="submit" class="bg-blue-500 px-3 py-1 rounded text-white">
+            {{ $editingId ? 'Update' : 'Add' }}
+        </button>
+        @if($editingId)
+            <button type="button" wire:click="$set('editingId', null)">Cancel</button>
+        @endif
+    </form>
+
+    <table class="min-w-full bg-white dark:bg-zinc-800 text-sm">
+        <thead>
+            <tr>
+                <th class="p-2">Name</th>
+                <th class="p-2">Slug</th>
+                <th class="p-2">Action</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($categories as $category)
+                <tr>
+                    <td class="p-2">{{ $category->name }}</td>
+                    <td class="p-2">{{ $category->slug }}</td>
+                    <td class="p-2 space-x-2">
+                        <button wire:click="edit({{ $category->id }})" class="text-blue-500">Edit</button>
+                        <button wire:click="delete({{ $category->id }})" class="text-red-600">Delete</button>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -15,6 +15,8 @@
 
                 <a href="{{ route('admin.approve-sellers') }}" class="block">Duyệt Seller</a>
 
+                <a href="{{ route('admin.categories') }}" class="block">Categories</a>
+
             </nav>
         </aside>
         <div class="flex-1 flex flex-col">

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Livewire\Admin\Withdrawals;
 use App\Livewire\Admin\WalletLogs;
 use App\Livewire\Admin\AdminApproveSeller;
+use App\Livewire\Admin\ManageCategories;
 use App\Livewire\Settings\Appearance;
 
 Route::middleware(['auth', 'adminOnly'])
@@ -15,6 +16,7 @@ Route::middleware(['auth', 'adminOnly'])
         Route::get('/withdrawals', Withdrawals::class)->name('withdrawals');
         Route::get('/wallet-logs', WalletLogs::class)->name('wallet-logs');
         Route::get('/approve-sellers', AdminApproveSeller::class)->name('approve-sellers');
+        Route::get('/categories', ManageCategories::class)->name('categories');
         Route::get('/appearance', Appearance::class)->name('appearance');
     });
 


### PR DESCRIPTION
## Summary
- add `ManageCategories` Livewire component
- show table/form in `admin.manage-categories` Blade
- register `/admin/categories` route
- add Categories link in admin layout

## Testing
- `./vendor/bin/phpunit` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_684d2d90097c8329a21311c393c4fb10