### PR TITLE
Add description field to Category fillable

### DIFF
--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -12,6 +12,7 @@ class Category extends Model
     protected $fillable = [
         'name',
         'slug',
+        'description',
     ];
 
     public function products()


### PR DESCRIPTION
## Summary
- allow mass assignment of `description` in `Category`

## Testing
- `php vendor/bin/phpunit` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d2f40cae88329b3fce6dfafd82077