### PR TITLE
Remove product reference from orders

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -4,7 +4,6 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use App\Models\Product;
 use App\Models\OrderItem;
 
 class Order extends Model
@@ -13,7 +12,6 @@ class Order extends Model
 
     protected $fillable = [
         'user_id',
-        'product_id',
         'amount',
         'status',
     ];
@@ -23,10 +21,6 @@ class Order extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
-    public function product()
-    {
-        return $this->belongsTo(Product::class);
-    }
 
     public function items()
     {

--- a/database/migrations/2024_01_01_000005_create_orders_table.php
+++ b/database/migrations/2024_01_01_000005_create_orders_table.php
@@ -12,7 +12,6 @@ return new class extends Migration
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
 
-            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
 
             $table->decimal('amount', 12, 2);
             $table->string('status')->default('pending');

--- a/tests/Feature/DownloadPdfTest.php
+++ b/tests/Feature/DownloadPdfTest.php
@@ -39,7 +39,6 @@ class DownloadPdfTest extends TestCase
 
         $order = Order::create([
             'user_id' => $buyer->id,
-            'product_id' => $product->id,
             'amount' => 10,
             'status' => 'completed',
         ]);


### PR DESCRIPTION
## Summary
- drop `product_id` from Orders table migration
- clean up the `Order` model
- update feature test to match new order fields
- regenerate the database migrations

## Testing
- `php artisan migrate:fresh --force`
- `php artisan test --testsuite Feature` *(fails: Route [settings.profile] not defined)*

------
https://chatgpt.com/codex/tasks/task_b_684d5c57f760832996ca5e0cc7795327