### PR TITLE
Implement appearance settings persistence

### DIFF
--- a/app/Livewire/Settings/Appearance.php
+++ b/app/Livewire/Settings/Appearance.php
@@ -2,9 +2,25 @@
 
 namespace App\Livewire\Settings;
 
+use App\Models\Setting;
 use Livewire\Component;
 
 class Appearance extends Component
 {
-    //
+    public string $appearance = 'system';
+
+    public function mount(): void
+    {
+        $this->appearance = setting('appearance', 'system');
+    }
+
+    public function saveAppearance(): void
+    {
+        Setting::updateOrCreate(
+            ['key' => 'appearance'],
+            ['value' => $this->appearance]
+        );
+
+        $this->dispatch('appearance-updated');
+    }
 }

--- a/database/migrations/2024_01_01_000018_add_appearance_setting.php
+++ b/database/migrations/2024_01_01_000018_add_appearance_setting.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::table('settings')->insertOrIgnore([
+            'key' => 'appearance',
+            'value' => 'system',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('settings')->where('key', 'appearance')->delete();
+    }
+};

--- a/resources/views/livewire/settings/appearance.blade.php
+++ b/resources/views/livewire/settings/appearance.blade.php
@@ -2,10 +2,22 @@
     @include('partials.settings-heading')
 
     <x-settings.layout :heading="__('Appearance')" :subheading=" __('Update the appearance settings for your account')">
-        <flux:radio.group x-data variant="segmented" x-model="$flux.appearance">
-            <flux:radio value="light" icon="sun">{{ __('Light') }}</flux:radio>
-            <flux:radio value="dark" icon="moon">{{ __('Dark') }}</flux:radio>
-            <flux:radio value="system" icon="computer-desktop">{{ __('System') }}</flux:radio>
-        </flux:radio.group>
+        <form wire:submit="saveAppearance" class="my-6 w-full space-y-6">
+            <flux:radio.group x-data variant="segmented" x-model="$flux.appearance" wire:model="appearance">
+                <flux:radio value="light" icon="sun">{{ __('Light') }}</flux:radio>
+                <flux:radio value="dark" icon="moon">{{ __('Dark') }}</flux:radio>
+                <flux:radio value="system" icon="computer-desktop">{{ __('System') }}</flux:radio>
+            </flux:radio.group>
+
+            <div class="flex items-center gap-4">
+                <div class="flex items-center justify-end">
+                    <flux:button variant="primary" type="submit" class="w-full">{{ __('Save') }}</flux:button>
+                </div>
+
+                <x-action-message class="me-3" on="appearance-updated">
+                    {{ __('Saved.') }}
+                </x-action-message>
+            </div>
+        </form>
     </x-settings.layout>
 </section>

--- a/tests/Feature/Settings/AppearanceUpdateTest.php
+++ b/tests/Feature/Settings/AppearanceUpdateTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Settings;
+
+use App\Livewire\Settings\Appearance;
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AppearanceUpdateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_appearance_page_is_displayed(): void
+    {
+        $this->actingAs(User::factory()->create());
+
+        $this->get('/settings/appearance')->assertOk();
+    }
+
+    public function test_appearance_can_be_updated(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $response = Livewire::test(Appearance::class)
+            ->set('appearance', 'dark')
+            ->call('saveAppearance');
+
+        $response->assertHasNoErrors();
+
+        $this->assertDatabaseHas('settings', [
+            'key' => 'appearance',
+            'value' => 'dark',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- store theme selection in the `settings` table
- allow choosing and saving appearance via Livewire
- provide migration seed
- add tests for appearance settings

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d63a0632c8329922415fa8f0c6e02