### PR TITLE
Refactor header and add footer

### DIFF
--- a/resources/views/components/layouts/footer.blade.php
+++ b/resources/views/components/layouts/footer.blade.php
@@ -1,0 +1,7 @@
+<footer class="bg-[#00796B] text-white p-4 mt-8">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center sm:text-left">
+        <div>Giới thiệu</div>
+        <div>Hướng dẫn</div>
+        <div>Liên hệ</div>
+    </div>
+</footer>

--- a/resources/views/components/layouts/header.blade.php
+++ b/resources/views/components/layouts/header.blade.php
@@ -1,0 +1,29 @@
+<header class="bg-[#00796B] p-4 flex justify-between items-center">
+    <a href="{{ route('home') }}" class="font-bold" wire:navigate>Choso</a>
+    <nav class="flex items-center gap-4">
+        @auth
+            @if(auth()->user()->role === 'seller')
+                <a href="{{ route('seller.dashboard') }}" wire:navigate>Tổng quan</a>
+                <a href="{{ route('seller.revenue') }}" wire:navigate>Doanh thu</a>
+                <a href="{{ route('seller.coupons') }}" wire:navigate>Coupons</a>
+                <a href="{{ route('seller.withdraw') }}" wire:navigate>Rút Scoin</a>
+                <a href="{{ route('seller.wallet-logs') }}" wire:navigate>Lịch sử ví</a>
+            @else
+                <a href="{{ route('shop.wallet-logs') }}" wire:navigate>Lịch sử ví</a>
+            @endif
+            <a href="{{ route('orders.history') }}" wire:navigate>Order History</a>
+            <a href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">Logout</a>
+            <form id="logout-form" method="POST" action="{{ route('logout') }}" class="hidden">@csrf</form>
+        @else
+            <a href="{{ route('login') }}" wire:navigate>Login</a>
+        @endauth
+        <a href="#" class="relative">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 2.25h1.591c.46 0 .868.314.978.761L5.94 7.5m0 0H19.5l-.862 4.311a1.5 1.5 0 01-1.478 1.189H7.125a1.5 1.5 0 01-1.478-1.189L5.94 7.5m0 0L5.25 4.5m0 0L4.219 2.435A.75.75 0 003.5 2.25H2.25m8.25 18.75a.75.75 0 100-1.5.75.75 0 000 1.5zm6.75 0a.75.75 0 100-1.5.75.75 0 000 1.5z" />
+            </svg>
+            <span class="absolute -top-1 -right-2 bg-red-600 text-xs rounded-full px-1">
+                {{ count(session('cart.items', [])) }}
+            </span>
+        </a>
+    </nav>
+</header>

--- a/resources/views/components/layouts/market.blade.php
+++ b/resources/views/components/layouts/market.blade.php
@@ -4,33 +4,14 @@
         @include('partials.head')
     </head>
     <body class="min-h-screen bg-[#111827] text-white">
-        <header class="bg-[#00796B] p-4 flex justify-between items-center">
-            <a href="{{ route('home') }}" class="font-bold" wire:navigate>Choso</a>
-            <nav class="flex gap-4">
-                @auth
-                    @if(auth()->user()->role === 'seller')
-                        <a href="{{ route('seller.dashboard') }}" wire:navigate>Tổng quan</a>
-                        <a href="{{ route('seller.revenue') }}" wire:navigate>Doanh thu</a>
-                        <a href="{{ route('seller.coupons') }}" wire:navigate>Coupons</a>
-                        <a href="{{ route('seller.withdraw') }}" wire:navigate>Rút Scoin</a>
-                        <a href="{{ route('seller.wallet-logs') }}" wire:navigate>Lịch sử ví</a>
-                    @else
-                        <a href="{{ route('shop.wallet-logs') }}" wire:navigate>Lịch sử ví</a>
-                    @endif
-                    <a href="{{ route('orders.history') }}" wire:navigate>Order History</a>
-                    <a href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">Logout</a>
-                    <form id="logout-form" method="POST" action="{{ route('logout') }}" class="hidden">@csrf</form>
-                @else
-                    <a href="{{ route('login') }}" wire:navigate>Login</a>
-                @endauth
-            </nav>
-        </header>
+        <x-layouts.header />
         <main class="p-6">
             {{ $slot }}
         </main>
         <aside class="fixed top-16 right-0 w-64 h-full bg-[#111827] border-l border-[#374151] p-4 overflow-y-auto">
             <livewire:shop.cart />
         </aside>
+        <x-layouts.footer />
         @fluxScripts
     </body>
 </html>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -25,10 +25,11 @@
             </nav>
         </aside>
         <div class="flex-1 flex flex-col">
-            <header class="bg-gray-800 text-white p-4">Admin Panel</header>
+            <x-layouts.header />
             <main class="flex-1 p-6">
                 {{ $slot }}
             </main>
+            <x-layouts.footer />
         </div>
     </div>
     @fluxScripts


### PR DESCRIPTION
## Summary
- move market header to `resources/views/components/layouts/header.blade.php`
- create a simple footer with three columns
- reuse header and footer in market layout
- include header and footer in the admin layout

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d72a612688329a215044d39ace2d9