### PR TITLE
Improve product page layout

### DIFF
--- a/app/Livewire/Product/Show.php
+++ b/app/Livewire/Product/Show.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Product;
 
 use App\Models\Product;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 
@@ -10,12 +11,26 @@ use Livewire\Component;
 class Show extends Component
 {
     public Product $product;
+    public ?string $licenseKey = null;
 
     public function mount(string $slug): void
     {
         $this->product = Product::where('slug', $slug)
             ->with('category', 'seller')
             ->firstOrFail();
+
+        $user = Auth::user();
+        if ($user) {
+            $order = $user->orders()
+                ->whereHas('items', fn ($q) => $q->where('product_id', $this->product->id))
+                ->with('licenseKey')
+                ->latest()
+                ->first();
+
+            if ($order && $order->licenseKey) {
+                $this->licenseKey = $order->licenseKey->key;
+            }
+        }
     }
 
     public function addToCart(): void

--- a/resources/views/product/show.blade.php
+++ b/resources/views/product/show.blade.php
@@ -7,17 +7,26 @@
 <meta property="og:url" content="{{ url()->current() }}">
 @endpush
 
-<div class="max-w-3xl mx-auto space-y-6">
-    <img src="{{ $product->cover_url }}" alt="{{ $product->name }}" class="w-full rounded">
-    <h1 class="text-2xl font-bold">{{ $product->name }}</h1>
-    @if($product->category)
-        <p class="text-sm text-gray-400">{{ $product->category->name }}</p>
-    @endif
-    <div class="prose prose-invert">
-        {!! $product->description !!}
+<div class="max-w-5xl mx-auto grid gap-8 md:grid-cols-2">
+    <div>
+        <img src="{{ $product->cover_url }}" alt="{{ $product->name }}" class="w-full rounded">
     </div>
-    <div class="flex items-center gap-2 mt-4">
-        <span class="font-semibold">{{ $product->seller->name }}</span>
+    <div class="space-y-6">
+        <h1 class="text-2xl font-bold">{{ $product->name }}</h1>
+        @if($product->category)
+            <p class="text-sm text-brand-gray">{{ $product->category->name }}</p>
+        @endif
+        <div class="prose prose-invert">
+            {!! $product->description !!}
+        </div>
+        <div class="flex items-center gap-2 mt-4">
+            <span class="font-semibold">{{ $product->seller->name }}</span>
+        </div>
+        <button wire:click="addToCart" class="bg-primary text-white px-4 py-2 rounded">Mua ngay</button>
+        @if($licenseKey)
+            <div class="bg-secondary text-dark p-2 rounded">
+                License: {{ $licenseKey }}
+            </div>
+        @endif
     </div>
-    <button wire:click="addToCart" class="bg-primary text-white px-4 py-2 rounded">Mua ngay</button>
 </div>


### PR DESCRIPTION
## Summary
- show license key if user already purchased the product
- use responsive two‑column layout for product page
- apply brand color utilities to category text and license box

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_b_684d8068b9748329adf3879c9fcf6ac4