### PR TITLE
Fix outline-hidden application

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -14,7 +14,8 @@
 input:focus[data-flux-control],
 textarea:focus[data-flux-control],
 select:focus[data-flux-control] {
-    @apply outline-hidden ring-2 ring-accent ring-offset-2 ring-offset-white;
+    outline: none;
+    @apply ring-2 ring-accent ring-offset-2 ring-offset-white;
 }
 
 /* \[:where(&)\]:size-4 {


### PR DESCRIPTION
## Summary
- replace `@apply outline-hidden` with `outline: none` and keep ring utilities

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d9c8bcb688329908f23fc94c429d9