### PR TITLE
Fix tailwind build warnings

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -3,7 +3,8 @@
 @tailwind utilities;
 
 [data-flux-field]:not(ui-radio, ui-checkbox) {
-    @apply grid gap-2;
+    display: grid;
+    gap: 0.5rem;
 }
 
 [data-flux-label] {
@@ -15,7 +16,8 @@ input:focus[data-flux-control],
 textarea:focus[data-flux-control],
 select:focus[data-flux-control] {
     outline: none;
-    @apply ring-2 ring-accent ring-offset-2 ring-offset-white;
+    outline: 2px solid #FFD54F;
+    outline-offset: 2px;
 }
 
 /* \[:where(&)\]:size-4 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,9 @@ export default {
         info: '#4FC3F7',
         danger: '#EF5350',
       },
+      ringColor: {
+        accent: '#FFD54F',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- fix Tailwind unknown utilities by replacing `@apply grid`, `gap-2`, and `ring-accent`
- extend Tailwind ring color config

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684d9dffe86c8329b78fb4338a0b513a