### PR TITLE
Add reactive cart count to header

### DIFF
--- a/app/Livewire/Header.php
+++ b/app/Livewire/Header.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Livewire;
+
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class Header extends Component
+{
+    public int $count = 0;
+
+    public function mount(): void
+    {
+        $this->count = count(session('cart.items', []));
+    }
+
+    #[On('cart-updated')]
+    public function updateCount(int $count): void
+    {
+        $this->count = $count;
+    }
+
+    public function render()
+    {
+        return view('components.layouts.header');
+    }
+}

--- a/app/Livewire/Shop/Cart.php
+++ b/app/Livewire/Shop/Cart.php
@@ -38,18 +38,21 @@ class Cart extends Component
         }
 
         app(CartService::class)->storeToSession($this->items);
+        $this->dispatch('cart-updated', count: count($this->items));
     }
 
     public function remove(int $productId): void
     {
         unset($this->items[$productId]);
         app(CartService::class)->storeToSession($this->items);
+        $this->dispatch('cart-updated', count: count($this->items));
     }
 
     public function clear(): void
     {
         $this->items = [];
         app(CartService::class)->clearSession();
+        $this->dispatch('cart-updated', count: 0);
     }
 
     #[On('cart-cleared')]

--- a/resources/views/components/layouts/header.blade.php
+++ b/resources/views/components/layouts/header.blade.php
@@ -22,7 +22,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 2.25h1.591c.46 0 .868.314.978.761L5.94 7.5m0 0H19.5l-.862 4.311a1.5 1.5 0 01-1.478 1.189H7.125a1.5 1.5 0 01-1.478-1.189L5.94 7.5m0 0L5.25 4.5m0 0L4.219 2.435A.75.75 0 003.5 2.25H2.25m8.25 18.75a.75.75 0 100-1.5.75.75 0 000 1.5zm6.75 0a.75.75 0 100-1.5.75.75 0 000 1.5z" />
             </svg>
             <span class="absolute -top-1 -right-2 bg-red-600 text-xs rounded-full px-1">
-                {{ count(session('cart.items', [])) }}
+                {{ $count }}
             </span>
         </button>
     </nav>

--- a/resources/views/components/layouts/market.blade.php
+++ b/resources/views/components/layouts/market.blade.php
@@ -4,7 +4,7 @@
         @include('partials.head')
     </head>
     <body class="min-h-screen bg-dark text-white" x-data="{ filtersOpen: false }">
-        <x-layouts.header />
+        <livewire:header />
         <div class="flex">
             <aside class="hidden md:block w-64 border-r border-brand-gray p-4">
                 <livewire:shop.category-filter />

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -25,7 +25,7 @@
             </nav>
         </aside>
         <div class="flex-1 flex flex-col">
-            <x-layouts.header />
+            <livewire:header />
             <main class="flex-1 p-6">
                 {{ $slot }}
             </main>


### PR DESCRIPTION
## Summary
- make a new `Header` Livewire component
- dispatch `cart-updated` events from the Cart component
- display cart item count reactively in the header view
- use `<livewire:header />` in layouts

## Testing
- `composer test` *(fails: Route [settings.profile] not defined)*

------
https://chatgpt.com/codex/tasks/task_b_684da3c746ac8329bdcebd8c8a28fea6