### PR TITLE
Refactor view colors to brand palette

### DIFF
--- a/resources/views/admin/approve-seller.blade.php
+++ b/resources/views/admin/approve-seller.blade.php
@@ -2,10 +2,10 @@
     <h1 class="text-xl font-semibold mb-4">{{ __('Duyệt Seller') }}</h1>
 
     @if(session('status'))
-        <div class="mb-4 text-green-600 dark:text-green-400">{{ session('status') }}</div>
+        <div class="mb-4 text-info">{{ session('status') }}</div>
     @endif
 
-    <table class="min-w-full bg-white dark:bg-zinc-800 text-sm">
+    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('Tên') }}</th>
@@ -21,7 +21,7 @@
                     <td class="p-2">{{ $seller->email }}</td>
                     <td class="p-2">{{ $seller->created_at->format('Y-m-d') }}</td>
                     <td class="p-2">
-                        <button wire:click="approve({{ $seller->id }})" class="text-green-600">{{ __('Duyệt') }}</button>
+                        <button wire:click="approve({{ $seller->id }})" class="text-info">{{ __('Duyệt') }}</button>
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/coupons.blade.php
+++ b/resources/views/admin/coupons.blade.php
@@ -2,7 +2,7 @@
     <h1 class="text-xl font-semibold mb-4">{{ __('Manage Coupons') }}</h1>
 
     @if(session('status'))
-        <div class="mb-4 text-green-600 dark:text-green-400">{{ session('status') }}</div>
+        <div class="mb-4 text-info">{{ session('status') }}</div>
     @endif
 
     <form wire:submit.prevent="save" class="mb-4 space-y-2">
@@ -15,14 +15,14 @@
             <input type="number" wire:model="value" placeholder="{{ __('Value') }}" class="border p-1 rounded w-24" step="0.01" />
             <input type="date" wire:model="expires_at" class="border p-1 rounded" />
             <input type="number" wire:model="usage_limit" placeholder="{{ __('Usage limit') }}" class="border p-1 rounded w-24" />
-            <button type="submit" class="bg-blue-500 text-white px-3 py-1 rounded">{{ $editingId ? __('Update') : __('Add') }}</button>
+            <button type="submit" class="bg-primary text-white px-3 py-1 rounded">{{ $editingId ? __('Update') : __('Add') }}</button>
             @if($editingId)
                 <button type="button" wire:click="$set('editingId', null)" class="px-2">{{ __('Cancel') }}</button>
             @endif
         </div>
     </form>
 
-    <table class="min-w-full bg-white dark:bg-zinc-800 text-sm">
+    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('Code') }}</th>
@@ -52,8 +52,8 @@
                         @endif
                     </td>
                     <td class="p-2 space-x-2">
-                        <button wire:click="edit({{ $coupon->id }})" class="text-blue-500">{{ __('Edit') }}</button>
-                        <button wire:click="delete({{ $coupon->id }})" class="text-red-600">{{ __('Delete') }}</button>
+                        <button wire:click="edit({{ $coupon->id }})" class="text-info">{{ __('Edit') }}</button>
+                        <button wire:click="delete({{ $coupon->id }})" class="text-danger">{{ __('Delete') }}</button>
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/manage-categories.blade.php
+++ b/resources/views/admin/manage-categories.blade.php
@@ -2,12 +2,12 @@
     <h1 class="text-xl font-semibold mb-4">{{ __('Manage Categories') }}</h1>
 
     @if(session('status'))
-        <div class="mb-4 text-green-600 dark:text-green-400">{{ session('status') }}</div>
+        <div class="mb-4 text-info">{{ session('status') }}</div>
     @endif
 
     <form wire:submit.prevent="save" class="mb-4 space-x-2">
         <input type="text" wire:model="name" placeholder="{{ __('Name') }}" class="border p-1 rounded" />
-        <button type="submit" class="bg-blue-500 px-3 py-1 rounded text-white">
+        <button type="submit" class="bg-primary px-3 py-1 rounded text-white">
             {{ $editingId ? __('Update') : __('Add') }}
         </button>
         @if($editingId)
@@ -15,7 +15,7 @@
         @endif
     </form>
 
-    <table class="min-w-full bg-white dark:bg-zinc-800 text-sm">
+    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('Name') }}</th>
@@ -29,8 +29,8 @@
                     <td class="p-2">{{ $category->name }}</td>
                     <td class="p-2">{{ $category->slug }}</td>
                     <td class="p-2 space-x-2">
-                        <button wire:click="edit({{ $category->id }})" class="text-blue-500">{{ __('Edit') }}</button>
-                        <button wire:click="delete({{ $category->id }})" class="text-red-600">{{ __('Delete') }}</button>
+                        <button wire:click="edit({{ $category->id }})" class="text-info">{{ __('Edit') }}</button>
+                        <button wire:click="delete({{ $category->id }})" class="text-danger">{{ __('Delete') }}</button>
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/top-up-wallet.blade.php
+++ b/resources/views/admin/top-up-wallet.blade.php
@@ -2,14 +2,14 @@
     <h1 class="text-xl font-semibold mb-4">{{ __('Top Up Wallet') }}</h1>
 
     @if(session('status'))
-        <div class="mb-4 text-green-600 dark:text-green-400">{{ session('status') }}</div>
+        <div class="mb-4 text-info">{{ session('status') }}</div>
     @endif
 
     <div class="mb-4">
         <input type="text" wire:model="search" placeholder="{{ __('Search') }}" class="border p-1 rounded" />
     </div>
 
-    <table class="min-w-full bg-white dark:bg-zinc-800 text-sm">
+    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('Name') }}</th>
@@ -27,7 +27,7 @@
                         <input type="number" wire:model.defer="amounts.{{ $user->id }}" class="border p-1 rounded w-24" />
                     </td>
                     <td class="p-2">
-                        <button wire:click="topUp({{ $user->id }})" class="text-blue-600">{{ __('Top Up') }}</button>
+                        <button wire:click="topUp({{ $user->id }})" class="text-info">{{ __('Top Up') }}</button>
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/wallet-logs.blade.php
+++ b/resources/views/admin/wallet-logs.blade.php
@@ -3,7 +3,7 @@
     <div class="mb-4">
         <input type="number" wire:model="userId" placeholder="{{ __('User ID') }}" class="border p-1 rounded" />
     </div>
-    <table class="min-w-full bg-white dark:bg-zinc-800 text-sm">
+    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('User') }}</th>

--- a/resources/views/admin/withdrawals.blade.php
+++ b/resources/views/admin/withdrawals.blade.php
@@ -1,6 +1,6 @@
 <div>
     <h1 class="text-xl font-semibold mb-4">{{ __('Yêu cầu rút tiền') }}</h1>
-    <table class="min-w-full bg-white dark:bg-zinc-800 text-sm">
+    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('User') }}</th>
@@ -17,8 +17,8 @@
                     <td class="p-2">{{ $withdrawal->status }}</td>
                     <td class="p-2 space-x-2">
                         @if($withdrawal->status === 'pending')
-                            <button wire:click="approve({{ $withdrawal->id }})" class="text-green-600">{{ __('Duyệt') }}</button>
-                            <button wire:click="reject({{ $withdrawal->id }})" class="text-red-600">{{ __('Từ chối') }}</button>
+                            <button wire:click="approve({{ $withdrawal->id }})" class="text-info">{{ __('Duyệt') }}</button>
+                            <button wire:click="reject({{ $withdrawal->id }})" class="text-danger">{{ __('Từ chối') }}</button>
                         @endif
                     </td>
                 </tr>

--- a/resources/views/components/auth-session-status.blade.php
+++ b/resources/views/components/auth-session-status.blade.php
@@ -3,7 +3,7 @@
 ])
 
 @if ($status)
-    <div {{ $attributes->merge(['class' => 'font-medium text-sm text-green-600']) }}>
+    <div {{ $attributes->merge(['class' => 'font-medium text-sm text-info']) }}>
         {{ $status }}
     </div>
 @endif

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -3,8 +3,8 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-white dark:bg-zinc-800">
-        <flux:header container class="border-b border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
+    <body class="min-h-screen bg-white dark:bg-brand-gray">
+        <flux:header container class="border-b border-brand-gray/20 bg-secondary dark:border-brand-gray/60 dark:bg-dark">
             <flux:sidebar.toggle class="lg:hidden" icon="bars-2" inset="left" />
 
             <a href="{{ route('dashboard') }}" class="ms-2 me-5 flex items-center space-x-2 rtl:space-x-reverse lg:ms-0" wire:navigate>
@@ -53,7 +53,7 @@
                             <div class="flex items-center gap-2 px-1 py-1.5 text-start text-sm">
                                 <span class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg">
                                     <span
-                                        class="flex h-full w-full items-center justify-center rounded-lg bg-neutral-200 text-black dark:bg-neutral-700 dark:text-white"
+                                        class="flex h-full w-full items-center justify-center rounded-lg bg-secondary text-dark dark:bg-brand-gray dark:text-white"
                                     >
                                         {{ auth()->user()->initials() }}
                                     </span>
@@ -86,7 +86,7 @@
         </flux:header>
 
         <!-- Mobile Menu -->
-        <flux:sidebar stashable sticky class="lg:hidden border-e border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
+        <flux:sidebar stashable sticky class="lg:hidden border-e border-brand-gray/20 bg-secondary dark:border-brand-gray/60 dark:bg-dark">
             <flux:sidebar.toggle class="lg:hidden" icon="x-mark" />
 
             <a href="{{ route('dashboard') }}" class="ms-1 flex items-center space-x-2 rtl:space-x-reverse" wire:navigate>

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -3,8 +3,8 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-white dark:bg-zinc-800">
-        <flux:sidebar sticky stashable class="border-e border-zinc-200 bg-zinc-50 dark:border-zinc-700 dark:bg-zinc-900">
+    <body class="min-h-screen bg-white dark:bg-brand-gray">
+        <flux:sidebar sticky stashable class="border-e border-brand-gray/20 bg-secondary dark:border-brand-gray/60 dark:bg-dark">
             <flux:sidebar.toggle class="lg:hidden" icon="x-mark" />
 
             <a href="{{ route('dashboard') }}" class="me-5 flex items-center space-x-2 rtl:space-x-reverse" wire:navigate>
@@ -43,7 +43,7 @@
                             <div class="flex items-center gap-2 px-1 py-1.5 text-start text-sm">
                                 <span class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg">
                                     <span
-                                        class="flex h-full w-full items-center justify-center rounded-lg bg-neutral-200 text-black dark:bg-neutral-700 dark:text-white"
+                                        class="flex h-full w-full items-center justify-center rounded-lg bg-secondary text-dark dark:bg-brand-gray dark:text-white"
                                     >
                                         {{ auth()->user()->initials() }}
                                     </span>
@@ -93,7 +93,7 @@
                             <div class="flex items-center gap-2 px-1 py-1.5 text-start text-sm">
                                 <span class="relative flex h-8 w-8 shrink-0 overflow-hidden rounded-lg">
                                     <span
-                                        class="flex h-full w-full items-center justify-center rounded-lg bg-neutral-200 text-black dark:bg-neutral-700 dark:text-white"
+                                        class="flex h-full w-full items-center justify-center rounded-lg bg-secondary text-dark dark:bg-brand-gray dark:text-white"
                                     >
                                         {{ auth()->user()->initials() }}
                                     </span>

--- a/resources/views/components/layouts/auth/card.blade.php
+++ b/resources/views/components/layouts/auth/card.blade.php
@@ -3,7 +3,7 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-neutral-100 antialiased dark:bg-linear-to-b dark:from-neutral-950 dark:to-neutral-900">
+    <body class="min-h-screen bg-secondary antialiased dark:bg-linear-to-b dark:from-dark dark:to-brand-gray">
         <div class="bg-muted flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
             <div class="flex w-full max-w-md flex-col gap-6">
                 <a href="{{ route('home') }}" class="flex flex-col items-center gap-2 font-medium" wire:navigate>
@@ -15,7 +15,7 @@
                 </a>
 
                 <div class="flex flex-col gap-6">
-                    <div class="rounded-xl border bg-white dark:bg-stone-950 dark:border-stone-800 text-stone-800 shadow-xs">
+                    <div class="rounded-xl border bg-white dark:bg-brand-gray dark:border-brand-gray text-brand-gray shadow-xs">
                         <div class="px-10 py-8">{{ $slot }}</div>
                     </div>
                 </div>

--- a/resources/views/components/layouts/auth/simple.blade.php
+++ b/resources/views/components/layouts/auth/simple.blade.php
@@ -3,7 +3,7 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-white antialiased dark:bg-linear-to-b dark:from-neutral-950 dark:to-neutral-900">
+    <body class="min-h-screen bg-white antialiased dark:bg-linear-to-b dark:from-dark dark:to-brand-gray">
         <div class="bg-background flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
             <div class="flex w-full max-w-sm flex-col gap-2">
                 <a href="{{ route('home') }}" class="flex flex-col items-center gap-2 font-medium" wire:navigate>

--- a/resources/views/components/layouts/auth/split.blade.php
+++ b/resources/views/components/layouts/auth/split.blade.php
@@ -3,10 +3,10 @@
     <head>
         @include('partials.head')
     </head>
-    <body class="min-h-screen bg-white antialiased dark:bg-linear-to-b dark:from-neutral-950 dark:to-neutral-900">
+    <body class="min-h-screen bg-white antialiased dark:bg-linear-to-b dark:from-dark dark:to-brand-gray">
         <div class="relative grid h-dvh flex-col items-center justify-center px-8 sm:px-0 lg:max-w-none lg:grid-cols-2 lg:px-0">
-            <div class="bg-muted relative hidden h-full flex-col p-10 text-white lg:flex dark:border-e dark:border-neutral-800">
-                <div class="absolute inset-0 bg-neutral-900"></div>
+            <div class="bg-muted relative hidden h-full flex-col p-10 text-white lg:flex dark:border-e dark:border-brand-gray">
+                <div class="absolute inset-0 bg-dark"></div>
                 <a href="{{ route('home') }}" class="relative z-20 flex items-center text-lg font-medium" wire:navigate>
                     <span class="flex h-10 w-10 items-center justify-center rounded-md">
                         <x-app-logo-icon class="me-2 h-7 fill-current text-white" />

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,18 +1,18 @@
 <x-layouts.app :title="__('Dashboard')">
     <div class="flex h-full w-full flex-1 flex-col gap-4 rounded-xl">
         <div class="grid auto-rows-min gap-4 md:grid-cols-3">
-            <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
-                <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
+            <div class="relative aspect-video overflow-hidden rounded-xl border border-brand-gray/30 dark:border-brand-gray/60">
+                <x-placeholder-pattern class="absolute inset-0 size-full stroke-brand-gray/50 dark:stroke-secondary/50" />
             </div>
-            <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
-                <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
+            <div class="relative aspect-video overflow-hidden rounded-xl border border-brand-gray/30 dark:border-brand-gray/60">
+                <x-placeholder-pattern class="absolute inset-0 size-full stroke-brand-gray/50 dark:stroke-secondary/50" />
             </div>
-            <div class="relative aspect-video overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
-                <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
+            <div class="relative aspect-video overflow-hidden rounded-xl border border-brand-gray/30 dark:border-brand-gray/60">
+                <x-placeholder-pattern class="absolute inset-0 size-full stroke-brand-gray/50 dark:stroke-secondary/50" />
             </div>
         </div>
-        <div class="relative h-full flex-1 overflow-hidden rounded-xl border border-neutral-200 dark:border-neutral-700">
-            <x-placeholder-pattern class="absolute inset-0 size-full stroke-gray-900/20 dark:stroke-neutral-100/20" />
+        <div class="relative h-full flex-1 overflow-hidden rounded-xl border border-brand-gray/30 dark:border-brand-gray/60">
+            <x-placeholder-pattern class="absolute inset-0 size-full stroke-brand-gray/50 dark:stroke-secondary/50" />
         </div>
     </div>
 </x-layouts.app>

--- a/resources/views/flux/navlist/group.blade.php
+++ b/resources/views/flux/navlist/group.blade.php
@@ -13,7 +13,7 @@
 >
     <button
         type="button"
-        class="group/disclosure-button mb-[2px] flex h-10 w-full items-center rounded-lg text-zinc-500 hover:bg-zinc-800/5 hover:text-zinc-800 lg:h-8 dark:text-white/80 dark:hover:bg-white/[7%] dark:hover:text-white"
+        class="group/disclosure-button mb-[2px] flex h-10 w-full items-center rounded-lg text-brand-gray hover:bg-brand-gray/10 hover:text-brand-gray lg:h-8 dark:text-white/80 dark:hover:bg-white/[7%] dark:hover:text-white"
     >
         <div class="ps-3 pe-4">
             <flux:icon.chevron-down class="hidden size-3! group-data-open/disclosure-button:block" />
@@ -24,7 +24,7 @@
     </button>
 
     <div class="relative hidden space-y-[2px] ps-7 data-open:block" @if ($expanded === true) data-open @endif>
-        <div class="absolute inset-y-[3px] start-0 ms-4 w-px bg-zinc-200 dark:bg-white/30"></div>
+        <div class="absolute inset-y-[3px] start-0 ms-4 w-px bg-brand-gray/20 dark:bg-white/30"></div>
 
         {{ $slot }}
     </div>
@@ -34,7 +34,7 @@
 
 <div {{ $attributes->class('block space-y-[2px]') }}>
     <div class="px-1 py-2">
-        <div class="text-xs leading-none text-zinc-400">{{ $heading }}</div>
+        <div class="text-xs leading-none text-brand-gray/60">{{ $heading }}</div>
     </div>
 
     <div>

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -19,7 +19,7 @@
         <flux:button variant="primary" type="submit" class="w-full">{{ __('Email password reset link') }}</flux:button>
     </form>
 
-    <div class="space-x-1 rtl:space-x-reverse text-center text-sm text-zinc-400">
+    <div class="space-x-1 rtl:space-x-reverse text-center text-sm text-brand-gray/60">
         {{ __('Or, return to') }}
         <flux:link :href="route('login')" wire:navigate>{{ __('log in') }}</flux:link>
     </div>

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -44,7 +44,7 @@
     </form>
 
     @if (Route::has('register'))
-        <div class="space-x-1 rtl:space-x-reverse text-center text-sm text-zinc-600 dark:text-zinc-400">
+        <div class="space-x-1 rtl:space-x-reverse text-center text-sm text-brand-gray dark:text-brand-gray/60">
             {{ __('Don\'t have an account?') }}
             <flux:link :href="route('register')" wire:navigate>{{ __('Sign up') }}</flux:link>
         </div>

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -55,7 +55,7 @@
         </div>
     </form>
 
-    <div class="space-x-1 rtl:space-x-reverse text-center text-sm text-zinc-600 dark:text-zinc-400">
+    <div class="space-x-1 rtl:space-x-reverse text-center text-sm text-brand-gray dark:text-brand-gray/60">
         {{ __('Already have an account?') }}
         <flux:link :href="route('login')" wire:navigate>{{ __('Log in') }}</flux:link>
     </div>

--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -4,7 +4,7 @@
     </flux:text>
 
     @if (session('status') == 'verification-link-sent')
-        <flux:text class="text-center font-medium !dark:text-green-400 !text-green-600">
+        <flux:text class="text-center font-medium !dark:text-info !text-info">
             {{ __('A new verification link has been sent to the email address you provided during registration.') }}
         </flux:text>
     @endif

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -19,7 +19,7 @@
                         </flux:text>
 
                         @if (session('status') === 'verification-link-sent')
-                            <flux:text class="mt-2 font-medium !dark:text-green-400 !text-green-600">
+                            <flux:text class="mt-2 font-medium !dark:text-info !text-info">
                                 {{ __('A new verification link has been sent to your email address.') }}
                             </flux:text>
                         @endif

--- a/resources/views/seller/dashboard.blade.php
+++ b/resources/views/seller/dashboard.blade.php
@@ -3,15 +3,15 @@
 
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
         <div class="border border-brand-gray p-4 rounded">
-            <p class="text-sm text-gray-400">{{ __('Doanh thu') }}</p>
+            <p class="text-sm text-brand-gray/60">{{ __('Doanh thu') }}</p>
             <p class="text-2xl font-semibold">{{ number_format($revenue) }} Scoin</p>
         </div>
         <div class="border border-brand-gray p-4 rounded">
-            <p class="text-sm text-gray-400">{{ __('Đơn hàng') }}</p>
+            <p class="text-sm text-brand-gray/60">{{ __('Đơn hàng') }}</p>
             <p class="text-2xl font-semibold">{{ $orderCount }}</p>
         </div>
         <div class="border border-brand-gray p-4 rounded">
-            <p class="text-sm text-gray-400">{{ __('Sản phẩm') }}</p>
+            <p class="text-sm text-brand-gray/60">{{ __('Sản phẩm') }}</p>
             <p class="text-2xl font-semibold">{{ $productCount }}</p>
         </div>
     </div>

--- a/resources/views/shop/checkout.blade.php
+++ b/resources/views/shop/checkout.blade.php
@@ -11,8 +11,8 @@
     </ul>
     <div class="space-x-2">
         <input type="text" wire:model="couponCode" placeholder="{{ __('Coupon code') }}" class="border p-1 rounded text-black" />
-        <button type="button" wire:click="applyCoupon" class="bg-blue-500 text-white px-2 py-1 rounded">{{ __('Apply') }}</button>
-        @error('couponCode') <span class="text-red-500">{{ $message }}</span> @enderror
+        <button type="button" wire:click="applyCoupon" class="bg-info text-white px-2 py-1 rounded">{{ __('Apply') }}</button>
+        @error('couponCode') <span class="text-danger">{{ $message }}</span> @enderror
     </div>
     @if($discount > 0)
         <div>{{ __('Discount') }}: -{{ number_format($discount) }} Scoin</div>

--- a/resources/views/shop/index.blade.php
+++ b/resources/views/shop/index.blade.php
@@ -2,7 +2,7 @@
     @foreach($products as $product)
         <a href="{{ route('shop.show', $product) }}" class="border border-brand-gray rounded p-4" wire:navigate>
             <h2 class="font-semibold text-lg">{{ $product->name }}</h2>
-            <p class="text-xs text-gray-400 mb-1">{{ $product->category?->name }}</p>
+            <p class="text-xs text-brand-gray/60 mb-1">{{ $product->category?->name }}</p>
             <p class="text-info">{{ number_format($product->price) }} Scoin</p>
         </a>
     @endforeach


### PR DESCRIPTION
## Summary
- replace generic grays in Blade views with colors from `tailwind.config.js`
- standardize tables, buttons and alerts on `primary`, `info`, and `danger`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684da6e7d7988329b47968c24659609a