### PR TITLE
Internationalize view text

### DIFF
--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -98,4 +98,5 @@ return [
     'Your Cart' => 'Your Cart',
     'Yêu cầu rút tiền' => 'Withdrawal Requests',
     'Đơn hàng' => 'Orders',
+    'Đơn hàng mới từ' => 'New order from',
 ];

--- a/resources/lang/vi/messages.php
+++ b/resources/lang/vi/messages.php
@@ -98,4 +98,5 @@ return [
     'Your Cart' => 'Giỏ hàng của bạn',
     'Yêu cầu rút tiền' => 'Yêu cầu rút tiền',
     'Đơn hàng' => 'Đơn hàng',
+    'Đơn hàng mới từ' => 'Đơn hàng mới từ',
 ];

--- a/resources/views/components/app-logo.blade.php
+++ b/resources/views/components/app-logo.blade.php
@@ -2,5 +2,5 @@
     <x-app-logo-icon class="size-5 fill-current text-white dark:text-black" />
 </div>
 <div class="ms-1 grid flex-1 text-start text-sm">
-    <span class="mb-0.5 truncate leading-tight font-semibold">Laravel Starter Kit</span>
+    <span class="mb-0.5 truncate leading-tight font-semibold">{{ __('Laravel Starter Kit') }}</span>
 </div>

--- a/resources/views/components/layouts/footer.blade.php
+++ b/resources/views/components/layouts/footer.blade.php
@@ -1,7 +1,7 @@
 <footer class="bg-primary text-white p-4 mt-8">
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center sm:text-left">
-        <div>Giới thiệu</div>
-        <div>Hướng dẫn</div>
-        <div>Liên hệ</div>
+        <div>{{ __('Giới thiệu') }}</div>
+        <div>{{ __('Hướng dẫn') }}</div>
+        <div>{{ __('Liên hệ') }}</div>
     </div>
 </footer>

--- a/resources/views/components/layouts/header.blade.php
+++ b/resources/views/components/layouts/header.blade.php
@@ -1,21 +1,21 @@
 <header class="bg-primary p-4 flex justify-between items-center">
-    <a href="{{ route('home') }}" class="font-bold" wire:navigate>Choso</a>
+    <a href="{{ route('home') }}" class="font-bold" wire:navigate>{{ __('Choso') }}</a>
     <nav class="flex items-center gap-4">
         @auth
             @if(auth()->user()->role === 'seller')
-                <a href="{{ route('seller.dashboard') }}" wire:navigate>Tổng quan</a>
-                <a href="{{ route('seller.revenue') }}" wire:navigate>Doanh thu</a>
-                <a href="{{ route('seller.coupons') }}" wire:navigate>Coupons</a>
-                <a href="{{ route('seller.withdraw') }}" wire:navigate>Rút Scoin</a>
-                <a href="{{ route('seller.wallet-logs') }}" wire:navigate>Lịch sử ví</a>
+                <a href="{{ route('seller.dashboard') }}" wire:navigate>{{ __('Tổng quan') }}</a>
+                <a href="{{ route('seller.revenue') }}" wire:navigate>{{ __('Doanh thu') }}</a>
+                <a href="{{ route('seller.coupons') }}" wire:navigate>{{ __('Coupons') }}</a>
+                <a href="{{ route('seller.withdraw') }}" wire:navigate>{{ __('Rút Scoin') }}</a>
+                <a href="{{ route('seller.wallet-logs') }}" wire:navigate>{{ __('Lịch sử ví') }}</a>
             @else
-                <a href="{{ route('shop.wallet-logs') }}" wire:navigate>Lịch sử ví</a>
+                <a href="{{ route('shop.wallet-logs') }}" wire:navigate>{{ __('Lịch sử ví') }}</a>
             @endif
-            <a href="{{ route('orders.history') }}" wire:navigate>Order History</a>
-            <a href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">Logout</a>
+            <a href="{{ route('orders.history') }}" wire:navigate>{{ __('Order History') }}</a>
+            <a href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">{{ __('Logout') }}</a>
             <form id="logout-form" method="POST" action="{{ route('logout') }}" class="hidden">@csrf</form>
         @else
-            <a href="{{ route('login') }}" wire:navigate>Login</a>
+            <a href="{{ route('login') }}" wire:navigate>{{ __('Login') }}</a>
         @endauth
         <button type="button" class="relative" x-data @click="$dispatch('toggle-cart')">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">

--- a/resources/views/components/layouts/market.blade.php
+++ b/resources/views/components/layouts/market.blade.php
@@ -10,7 +10,7 @@
                 <livewire:shop.category-filter />
             </aside>
             <main class="flex-1 p-6">
-                <button class="md:hidden mb-4" @click="filtersOpen = !filtersOpen">Categories</button>
+                <button class="md:hidden mb-4" @click="filtersOpen = !filtersOpen">{{ __('Categories') }}</button>
                 <div x-show="filtersOpen" class="md:hidden mb-4 border border-brand-gray p-4">
                     <livewire:shop.category-filter />
                 </div>

--- a/resources/views/emails/new_order_notification.blade.php
+++ b/resources/views/emails/new_order_notification.blade.php
@@ -1,9 +1,9 @@
 <div>
-    <p>📦 Đơn hàng mới từ {{ $order->buyer->email }}</p>
+    <p>📦 {{ __('Đơn hàng mới từ') }} {{ $order->buyer->email }}</p>
     <ul>
         @foreach($order->items as $item)
             <li>{{ $item->product->name }} x {{ $item->quantity }} - {{ number_format($item->price) }}đ</li>
         @endforeach
     </ul>
-    <p>Tổng: {{ number_format($order->amount) }}đ</p>
+    <p>{{ __('Total') }}: {{ number_format($order->amount) }}đ</p>
 </div>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -6,20 +6,20 @@
 <body class="min-h-screen bg-secondary dark:bg-dark text-dark dark:text-white">
     <div class="flex">
         <aside class="w-64 bg-brand-gray text-white min-h-screen p-4 space-y-2 dark:bg-brand-gray">
-            <a href="{{ route('admin.dashboard') }}" class="font-bold block mb-4">Admin</a>
+            <a href="{{ route('admin.dashboard') }}" class="font-bold block mb-4">{{ __('Admin') }}</a>
             <nav class="space-y-2">
-                <a href="{{ route('admin.dashboard') }}" class="block">Dashboard</a>
-                <a href="{{ route('admin.withdrawals') }}" class="block">Yêu cầu rút tiền</a>
+                <a href="{{ route('admin.dashboard') }}" class="block">{{ __('Dashboard') }}</a>
+                <a href="{{ route('admin.withdrawals') }}" class="block">{{ __('Yêu cầu rút tiền') }}</a>
 
-                <a href="{{ route('admin.wallet-logs') }}" class="block">Lịch sử ví</a>
+                <a href="{{ route('admin.wallet-logs') }}" class="block">{{ __('Lịch sử ví') }}</a>
 
 
-                <a href="{{ route('admin.topup-wallet') }}" class="block">Nạp ví cho user</a>
+                <a href="{{ route('admin.topup-wallet') }}" class="block">{{ __('Nạp ví cho user') }}</a>
 
-                <a href="{{ route('admin.approve-sellers') }}" class="block">Duyệt Seller</a>
+                <a href="{{ route('admin.approve-sellers') }}" class="block">{{ __('Duyệt Seller') }}</a>
 
-                <a href="{{ route('admin.categories') }}" class="block">Categories</a>
-                <a href="{{ route('admin.coupons') }}" class="block">Coupons</a>
+                <a href="{{ route('admin.categories') }}" class="block">{{ __('Categories') }}</a>
+                <a href="{{ route('admin.coupons') }}" class="block">{{ __('Coupons') }}</a>
 
 
             </nav>

--- a/resources/views/shop/show.blade.php
+++ b/resources/views/shop/show.blade.php
@@ -2,5 +2,5 @@
     <h1 class="text-2xl font-semibold">{{ $product->name }}</h1>
     <p>{{ $product->description }}</p>
     <p class="text-accent font-semibold">{{ number_format($product->price) }} Scoin</p>
-    <button wire:click="dispatch('add-to-cart', id: $product->id)" class="bg-primary text-white px-4 py-2 rounded">Add to Cart</button>
+    <button wire:click="dispatch('add-to-cart', id: $product->id)" class="bg-primary text-white px-4 py-2 rounded">{{ __('Add to Cart') }}</button>
 </div>


### PR DESCRIPTION
## Summary
- wrap untranslated header/nav text in translation calls
- localize market layout, footer, app logo and checkout button
- translate new order notification email text
- add missing language strings

## Testing
- `composer test` *(fails: command not found)*
- `php vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684dac434744832989a81a2952cbd2cc