### PR TITLE
Add price section with sales badge

### DIFF
--- a/app/Livewire/Product/Show.php
+++ b/app/Livewire/Product/Show.php
@@ -17,6 +17,7 @@ class Show extends Component
     {
         $this->product = Product::where('slug', $slug)
             ->with('category', 'seller')
+            ->withSum('orderItems as sales_count', 'quantity')
             ->firstOrFail();
 
         $user = Auth::user();

--- a/resources/views/product/show.blade.php
+++ b/resources/views/product/show.blade.php
@@ -16,13 +16,18 @@
         @if($product->category)
             <p class="text-sm text-brand-gray">{{ $product->category->name }}</p>
         @endif
+        <div class="flex items-center gap-2">
+            <p class="text-accent font-semibold">{{ number_format($product->price) }} Scoin</p>
+            <span class="bg-primary text-white text-xs px-2 py-0.5 rounded">{{ __('Instant download') }}</span>
+            <span class="text-sm text-brand-gray">{{ number_format($product->sales_count ?? 0) }} {{ __('Số lượt bán') }}</span>
+        </div>
         <div class="prose prose-invert">
             {!! $product->description !!}
         </div>
         <div class="flex items-center gap-2 mt-4">
             <span class="font-semibold">{{ $product->seller->name }}</span>
         </div>
-        <button wire:click="addToCart" class="bg-primary text-white px-4 py-2 rounded">{{ __('Mua ngay') }}</button>
+        <button wire:click="addToCart" class="bg-primary text-white px-4 py-2 rounded focus:outline-none focus:ring-2 focus:ring-accent">{{ __('Mua ngay') }}</button>
         @if($licenseKey)
             <div class="bg-secondary text-dark p-2 rounded">
                 {{ __('License') }}: {{ $licenseKey }}


### PR DESCRIPTION
## Summary
- load product sales count in product component
- display price with instant download badge and sales count
- keep `Mua ngay` button with accent focus ring

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684db62428188329b69d9328dff3b762