### PR TITLE
Improve header and footer layout

### DIFF
--- a/resources/views/components/layouts/footer.blade.php
+++ b/resources/views/components/layouts/footer.blade.php
@@ -1,7 +1,18 @@
-<footer class="bg-primary text-white p-4 mt-8">
-    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 text-center sm:text-left">
-        <div>{{ __('Giới thiệu') }}</div>
-        <div>{{ __('Hướng dẫn') }}</div>
-        <div>{{ __('Liên hệ') }}</div>
+<footer class="bg-dark text-white p-6 mt-8">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-center md:text-left">
+        <div>
+            <h3 class="font-semibold mb-2">{{ __('Giới thiệu') }}</h3>
+            <p class="text-sm">{{ __('Choso Digital Marketplace') }}</p>
+        </div>
+        <div>
+            <h3 class="font-semibold mb-2">{{ __('Hướng dẫn') }}</h3>
+            <ul class="space-y-1 text-sm">
+                <li><a href="{{ route('orders.history') }}" class="hover:text-accent">{{ __('Đơn hàng') }}</a></li>
+            </ul>
+        </div>
+        <div>
+            <h3 class="font-semibold mb-2">{{ __('Liên hệ') }}</h3>
+            <p class="text-sm">support@example.com</p>
+        </div>
     </div>
 </footer>

--- a/resources/views/components/layouts/header.blade.php
+++ b/resources/views/components/layouts/header.blade.php
@@ -1,23 +1,23 @@
-<header class="bg-primary p-4 flex justify-between items-center">
-    <a href="{{ route('home') }}" class="font-bold" wire:navigate>{{ __('Choso') }}</a>
+<header class="bg-primary text-white p-4 flex items-center">
+    <a href="{{ route('home') }}" class="font-bold mr-auto" wire:navigate>{{ __('Choso') }}</a>
     <nav class="flex items-center gap-4">
         @auth
             @if(auth()->user()->role === 'seller')
-                <a href="{{ route('seller.dashboard') }}" wire:navigate>{{ __('Tổng quan') }}</a>
-                <a href="{{ route('seller.revenue') }}" wire:navigate>{{ __('Doanh thu') }}</a>
-                <a href="{{ route('seller.coupons') }}" wire:navigate>{{ __('Coupons') }}</a>
-                <a href="{{ route('seller.withdraw') }}" wire:navigate>{{ __('Rút Scoin') }}</a>
-                <a href="{{ route('seller.wallet-logs') }}" wire:navigate>{{ __('Lịch sử ví') }}</a>
+                <a href="{{ route('seller.dashboard') }}" wire:navigate class="hover:text-accent">{{ __('Tổng quan') }}</a>
+                <a href="{{ route('seller.revenue') }}" wire:navigate class="hover:text-accent">{{ __('Doanh thu') }}</a>
+                <a href="{{ route('seller.coupons') }}" wire:navigate class="hover:text-accent">{{ __('Coupons') }}</a>
+                <a href="{{ route('seller.withdraw') }}" wire:navigate class="hover:text-accent">{{ __('Rút Scoin') }}</a>
+                <a href="{{ route('seller.wallet-logs') }}" wire:navigate class="hover:text-accent">{{ __('Lịch sử ví') }}</a>
             @else
-                <a href="{{ route('shop.wallet-logs') }}" wire:navigate>{{ __('Lịch sử ví') }}</a>
+                <a href="{{ route('shop.wallet-logs') }}" wire:navigate class="hover:text-accent">{{ __('Lịch sử ví') }}</a>
             @endif
-            <a href="{{ route('orders.history') }}" wire:navigate>{{ __('Order History') }}</a>
-            <a href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">{{ __('Logout') }}</a>
+            <a href="{{ route('orders.history') }}" wire:navigate class="hover:text-accent">{{ __('Order History') }}</a>
+            <a href="{{ route('logout') }}" onclick="event.preventDefault(); document.getElementById('logout-form').submit();" class="hover:text-accent">{{ __('Logout') }}</a>
             <form id="logout-form" method="POST" action="{{ route('logout') }}" class="hidden">@csrf</form>
         @else
-            <a href="{{ route('login') }}" wire:navigate>{{ __('Login') }}</a>
+            <a href="{{ route('login') }}" wire:navigate class="hover:text-accent">{{ __('Login') }}</a>
         @endauth
-        <button type="button" class="relative" x-data @click="$dispatch('toggle-cart')">
+        <button type="button" class="relative hover:text-accent" x-data @click="$dispatch('toggle-cart')">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 2.25h1.591c.46 0 .868.314.978.761L5.94 7.5m0 0H19.5l-.862 4.311a1.5 1.5 0 01-1.478 1.189H7.125a1.5 1.5 0 01-1.478-1.189L5.94 7.5m0 0L5.25 4.5m0 0L4.219 2.435A.75.75 0 003.5 2.25H2.25m8.25 18.75a.75.75 0 100-1.5.75.75 0 000 1.5zm6.75 0a.75.75 0 100-1.5.75.75 0 000 1.5z" />
             </svg>


### PR DESCRIPTION
## Summary
- align header content so logo is on the left and navigation on the right
- style navigation links with accent colour on hover
- dark themed footer split into three columns

## Testing
- `php vendor/bin/phpunit` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_b_684db6ff98748329bc3cec834ecc5450