### PR TITLE
Apply card layouts and unify button colors

### DIFF
--- a/resources/views/admin/approve-seller.blade.php
+++ b/resources/views/admin/approve-seller.blade.php
@@ -5,7 +5,8 @@
         <div class="mb-4 text-info">{{ session('status') }}</div>
     @endif
 
-    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
+    <div class="border border-brand-gray rounded bg-secondary overflow-x-auto">
+    <table class="min-w-full text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('Tên') }}</th>
@@ -21,10 +22,11 @@
                     <td class="p-2">{{ $seller->email }}</td>
                     <td class="p-2">{{ $seller->created_at->format('Y-m-d') }}</td>
                     <td class="p-2">
-                        <button wire:click="approve({{ $seller->id }})" class="text-info">{{ __('Duyệt') }}</button>
+                        <button wire:click="approve({{ $seller->id }})" class="bg-info text-dark px-2 py-1 rounded">{{ __('Duyệt') }}</button>
                     </td>
                 </tr>
             @endforeach
         </tbody>
     </table>
+    </div>
 </div>

--- a/resources/views/admin/coupons.blade.php
+++ b/resources/views/admin/coupons.blade.php
@@ -22,7 +22,8 @@
         </div>
     </form>
 
-    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
+    <div class="border border-brand-gray rounded bg-secondary overflow-x-auto">
+    <table class="min-w-full text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('Code') }}</th>
@@ -52,11 +53,12 @@
                         @endif
                     </td>
                     <td class="p-2 space-x-2">
-                        <button wire:click="edit({{ $coupon->id }})" class="text-info">{{ __('Edit') }}</button>
+                        <button wire:click="edit({{ $coupon->id }})" class="bg-info text-dark px-2 py-1 rounded">{{ __('Edit') }}</button>
                         <button wire:click="delete({{ $coupon->id }})" class="text-danger">{{ __('Delete') }}</button>
                     </td>
                 </tr>
             @endforeach
         </tbody>
     </table>
+    </div>
 </div>

--- a/resources/views/admin/manage-categories.blade.php
+++ b/resources/views/admin/manage-categories.blade.php
@@ -15,7 +15,8 @@
         @endif
     </form>
 
-    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
+    <div class="border border-brand-gray rounded bg-secondary overflow-x-auto">
+    <table class="min-w-full text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('Name') }}</th>
@@ -29,11 +30,12 @@
                     <td class="p-2">{{ $category->name }}</td>
                     <td class="p-2">{{ $category->slug }}</td>
                     <td class="p-2 space-x-2">
-                        <button wire:click="edit({{ $category->id }})" class="text-info">{{ __('Edit') }}</button>
+                        <button wire:click="edit({{ $category->id }})" class="bg-info text-dark px-2 py-1 rounded">{{ __('Edit') }}</button>
                         <button wire:click="delete({{ $category->id }})" class="text-danger">{{ __('Delete') }}</button>
                     </td>
                 </tr>
             @endforeach
         </tbody>
     </table>
+    </div>
 </div>

--- a/resources/views/admin/top-up-wallet.blade.php
+++ b/resources/views/admin/top-up-wallet.blade.php
@@ -9,7 +9,8 @@
         <input type="text" wire:model="search" placeholder="{{ __('Search') }}" class="border p-1 rounded" />
     </div>
 
-    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
+    <div class="border border-brand-gray rounded bg-secondary overflow-x-auto">
+    <table class="min-w-full text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('Name') }}</th>
@@ -27,10 +28,11 @@
                         <input type="number" wire:model.defer="amounts.{{ $user->id }}" class="border p-1 rounded w-24" />
                     </td>
                     <td class="p-2">
-                        <button wire:click="topUp({{ $user->id }})" class="text-info">{{ __('Top Up') }}</button>
+                        <button wire:click="topUp({{ $user->id }})" class="bg-info text-dark px-2 py-1 rounded">{{ __('Top Up') }}</button>
                     </td>
                 </tr>
             @endforeach
         </tbody>
     </table>
+    </div>
 </div>

--- a/resources/views/admin/wallet-logs.blade.php
+++ b/resources/views/admin/wallet-logs.blade.php
@@ -3,7 +3,8 @@
     <div class="mb-4">
         <input type="number" wire:model="userId" placeholder="{{ __('User ID') }}" class="border p-1 rounded" />
     </div>
-    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
+    <div class="border border-brand-gray rounded bg-secondary overflow-x-auto">
+    <table class="min-w-full text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('User') }}</th>
@@ -25,4 +26,5 @@
             @endforeach
         </tbody>
     </table>
+    </div>
 </div>

--- a/resources/views/admin/withdrawals.blade.php
+++ b/resources/views/admin/withdrawals.blade.php
@@ -1,6 +1,7 @@
 <div>
     <h1 class="text-xl font-semibold mb-4">{{ __('Yêu cầu rút tiền') }}</h1>
-    <table class="min-w-full bg-white dark:bg-brand-gray text-sm">
+    <div class="border border-brand-gray rounded bg-secondary overflow-x-auto">
+    <table class="min-w-full text-sm">
         <thead>
             <tr>
                 <th class="p-2">{{ __('User') }}</th>
@@ -17,7 +18,7 @@
                     <td class="p-2">{{ $withdrawal->status }}</td>
                     <td class="p-2 space-x-2">
                         @if($withdrawal->status === 'pending')
-                            <button wire:click="approve({{ $withdrawal->id }})" class="text-info">{{ __('Duyệt') }}</button>
+                            <button wire:click="approve({{ $withdrawal->id }})" class="bg-info text-dark px-2 py-1 rounded">{{ __('Duyệt') }}</button>
                             <button wire:click="reject({{ $withdrawal->id }})" class="text-danger">{{ __('Từ chối') }}</button>
                         @endif
                     </td>
@@ -25,4 +26,5 @@
             @endforeach
         </tbody>
     </table>
+    </div>
 </div>

--- a/resources/views/seller/create-product.blade.php
+++ b/resources/views/seller/create-product.blade.php
@@ -25,5 +25,5 @@
         <label class="block">{{ __('File') }}</label>
         <input type="file" wire:model="file" accept=".pdf,.zip" class="w-full" />
     </div>
-    <button type="submit" class="bg-primary px-4 py-2 rounded">{{ __('Save') }}</button>
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{{ __('Save') }}</button>
 </form>

--- a/resources/views/seller/dashboard.blade.php
+++ b/resources/views/seller/dashboard.blade.php
@@ -2,22 +2,23 @@
     <h1 class="text-xl font-semibold mb-4">{{ __('Tổng quan') }}</h1>
 
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
-        <div class="border border-brand-gray p-4 rounded">
+        <div class="border border-brand-gray bg-secondary p-4 rounded">
             <p class="text-sm text-brand-gray/60">{{ __('Doanh thu') }}</p>
             <p class="text-2xl font-semibold">{{ number_format($revenue) }} Scoin</p>
         </div>
-        <div class="border border-brand-gray p-4 rounded">
+        <div class="border border-brand-gray bg-secondary p-4 rounded">
             <p class="text-sm text-brand-gray/60">{{ __('Đơn hàng') }}</p>
             <p class="text-2xl font-semibold">{{ $orderCount }}</p>
         </div>
-        <div class="border border-brand-gray p-4 rounded">
+        <div class="border border-brand-gray bg-secondary p-4 rounded">
             <p class="text-sm text-brand-gray/60">{{ __('Sản phẩm') }}</p>
             <p class="text-2xl font-semibold">{{ $productCount }}</p>
         </div>
     </div>
 
     <h2 class="text-lg font-semibold mb-2">{{ __('Top sản phẩm') }}</h2>
-    <table class="w-full border border-brand-gray">
+    <div class="border border-brand-gray rounded bg-secondary overflow-x-auto">
+    <table class="w-full">
         <thead>
             <tr>
                 <th class="p-2 text-left">{{ __('Tên') }}</th>
@@ -37,4 +38,5 @@
             @endforeach
         </tbody>
     </table>
+    </div>
 </div>

--- a/resources/views/seller/edit-product.blade.php
+++ b/resources/views/seller/edit-product.blade.php
@@ -25,5 +25,5 @@
         <label class="block">{{ __('File') }}</label>
         <input type="file" wire:model="file" accept=".pdf,.zip" class="w-full" />
     </div>
-    <button type="submit" class="bg-primary px-4 py-2 rounded">{{ __('Update') }}</button>
+    <button type="submit" class="bg-primary text-white px-4 py-2 rounded">{{ __('Update') }}</button>
 </form>

--- a/resources/views/seller/my-products.blade.php
+++ b/resources/views/seller/my-products.blade.php
@@ -1,7 +1,7 @@
 <div>
     <h1 class="text-xl font-semibold mb-4">{{ __('My Products') }}</h1>
 
-    <a href="{{ route('seller.products.create') }}" class="bg-info text-black px-4 py-2 rounded" wire:navigate>{{ __('Add Product') }}</a>
+    <a href="{{ route('seller.products.create') }}" class="bg-info text-dark px-4 py-2 rounded" wire:navigate>{{ __('Add Product') }}</a>
 
 
 
@@ -10,7 +10,7 @@
             <li class="border border-brand-gray p-2 flex justify-between">
                 <span>{{ $product->name }}</span>
                 <div class="space-x-2">
-                    <a href="{{ route('seller.products.edit', $product) }}" class="text-info" wire:navigate>{{ __('Edit') }}</a>
+                    <a href="{{ route('seller.products.edit', $product) }}" class="bg-info text-dark px-2 py-1 rounded" wire:navigate>{{ __('Edit') }}</a>
                     <button type="button" wire:click="delete({{ $product->id }})" class="text-danger">{{ __('Delete') }}</button>
                 </div>
             </li>

--- a/resources/views/seller/revenue.blade.php
+++ b/resources/views/seller/revenue.blade.php
@@ -7,7 +7,8 @@
         </select>
     </div>
     <p class="mb-2">{{ __('Tổng tiền') }}: {{ number_format($total) }} Scoin</p>
-    <table class="w-full border border-brand-gray">
+    <div class="border border-brand-gray rounded bg-secondary overflow-x-auto">
+    <table class="w-full">
         <thead>
             <tr>
                 <th class="p-2 text-left">{{ __('Sản phẩm') }}</th>
@@ -25,4 +26,5 @@
             @endforeach
         </tbody>
     </table>
+    </div>
 </div>


### PR DESCRIPTION
## Summary
- wrap seller and admin tables in secondary cards with brand-gray borders
- add secondary background to seller dashboard metrics
- standardize action buttons with primary and info colors

## Testing
- `php vendor/bin/phpunit` *(fails: missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_b_684db707eb1c8329bf2245cc744e9db2