### PR TITLE
Replace bunny.net fonts with Google Fonts

### DIFF
--- a/resources/views/partials/head.blade.php
+++ b/resources/views/partials/head.blade.php
@@ -8,8 +8,7 @@
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
-<link rel="preconnect" href="https://fonts.bunny.net">
-<link href="https://fonts.bunny.net/css?family=inter:400,500,600" rel="stylesheet" />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
 
 @vite(['resources/css/app.css', 'resources/js/app.js'])
 @fluxAppearance


### PR DESCRIPTION
## Summary
- update head partial to use fonts from `fonts.googleapis.com`
- remove preconnect for bunny.net

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_684db9e17cdc83299e805a56dd360ea1