### PR TITLE
Add responsive market layout

### DIFF
--- a/resources/views/components/layouts/market.blade.php
+++ b/resources/views/components/layouts/market.blade.php
@@ -5,13 +5,13 @@
     </head>
     <body class="min-h-screen bg-dark text-white" x-data="{ filtersOpen: false }">
         <livewire:header />
-        <div class="flex">
-            <aside class="hidden md:block w-64 border-r border-brand-gray p-4">
+        <div class="grid grid-cols-1 lg:grid-cols-[16rem,1fr,16rem]">
+            <aside class="hidden lg:block border-r border-brand-gray p-4">
                 <livewire:shop.category-filter />
             </aside>
-            <main class="flex-1 p-6">
-                <button class="md:hidden mb-4" @click="filtersOpen = !filtersOpen">{{ __('Categories') }}</button>
-                <div x-show="filtersOpen" class="md:hidden mb-4 border border-brand-gray p-4">
+            <main class="p-6">
+                <button class="lg:hidden mb-4" @click="filtersOpen = !filtersOpen">{{ __('Categories') }}</button>
+                <div x-show="filtersOpen" class="lg:hidden mb-4 border border-brand-gray p-4">
                     <livewire:shop.category-filter />
                 </div>
                 {{ $slot }}

--- a/resources/views/shop/cart-drawer.blade.php
+++ b/resources/views/shop/cart-drawer.blade.php
@@ -1,6 +1,6 @@
 <div
     x-data="{ open: @entangle('open') }"
-    class="fixed top-16 bottom-0 right-0 w-64 bg-dark border-l border-brand-gray p-4 overflow-y-auto transform transition-transform duration-300 translate-x-full"
+    class="relative w-full lg:w-64 bg-dark border-t lg:border-t-0 lg:border-l border-brand-gray p-4 overflow-y-auto transform transition-transform duration-300 translate-x-full"
     :class="{ 'translate-x-0': open }"
 >
     <livewire:shop.cart />


### PR DESCRIPTION
## Summary
- redesign market layout to show filter, product grid, and cart drawer columns
- let the cart drawer slide in/out inside layout

## Testing
- `composer test` *(fails: Route [login] not defined, 18 failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_684db9eca008832997e0b2a146bb523d