### PR TITLE
Improve product show layout

### DIFF
--- a/resources/views/product/show.blade.php
+++ b/resources/views/product/show.blade.php
@@ -7,8 +7,8 @@
 <meta property="og:url" content="{{ url()->current() }}">
 @endpush
 
-<div class="max-w-5xl mx-auto grid gap-8 md:grid-cols-2">
-    <div>
+<div class="max-w-5xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8 items-start">
+    <div class="md:pr-8">
         <img src="{{ $product->cover_url }}" alt="{{ $product->name }}" class="w-full rounded">
     </div>
     <div class="space-y-6">
@@ -16,11 +16,9 @@
         @if($product->category)
             <p class="text-sm text-brand-gray">{{ $product->category->name }}</p>
         @endif
-        <div class="flex items-center gap-2">
-            <p class="text-accent font-semibold">{{ number_format($product->price) }} Scoin</p>
-            <span class="bg-primary text-white text-xs px-2 py-0.5 rounded">{{ __('Instant download') }}</span>
-            <span class="text-sm text-brand-gray">{{ number_format($product->sales_count ?? 0) }} {{ __('Số lượt bán') }}</span>
-        </div>
+        <p class="text-accent font-semibold">{{ number_format($product->price) }} Scoin</p>
+        <span class="inline-block bg-info text-dark text-xs px-2 py-0.5 rounded">{{ __('Instant download') }}</span>
+        <p class="text-sm text-brand-gray">Đã bán: {{ number_format($product->sales_count ?? 0) }} lượt</p>
         <div class="prose prose-invert">
             {!! $product->description !!}
         </div>


### PR DESCRIPTION
## Summary
- restructure product details page into two-column grid
- show 'Instant download' badge with info style
- show sales count line

## Testing
- `composer test` *(fails: composer not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684dbaae5b808329b334b3c634959782