### PR TITLE
Add responsive breakpoints to views

### DIFF
--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -4,8 +4,8 @@
     @include('partials.head')
 </head>
 <body class="min-h-screen bg-secondary dark:bg-dark text-dark dark:text-white">
-    <div class="flex">
-        <aside class="w-64 bg-brand-gray text-white min-h-screen p-4 space-y-2 dark:bg-brand-gray">
+    <div class="flex flex-col sm:flex-row">
+        <aside class="hidden sm:block sm:w-64 bg-brand-gray text-white min-h-screen p-4 space-y-2 dark:bg-brand-gray">
             <a href="{{ route('admin.dashboard') }}" class="font-bold block mb-4">{{ __('Admin') }}</a>
             <nav class="space-y-2">
                 <a href="{{ route('admin.dashboard') }}" class="block">{{ __('Dashboard') }}</a>

--- a/resources/views/seller/create-product.blade.php
+++ b/resources/views/seller/create-product.blade.php
@@ -1,4 +1,4 @@
-<form wire:submit.prevent="save" class="space-y-4">
+<form wire:submit.prevent="save" class="space-y-4 max-w-lg mx-auto p-4 sm:p-6">
     <h1 class="text-xl font-semibold">{{ __('Add Product') }}</h1>
     <div>
         <label class="block">{{ __('Name') }}</label>

--- a/resources/views/seller/dashboard.blade.php
+++ b/resources/views/seller/dashboard.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="px-4 sm:px-6">
     <h1 class="text-xl font-semibold mb-4">{{ __('Tổng quan') }}</h1>
 
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">

--- a/resources/views/seller/edit-product.blade.php
+++ b/resources/views/seller/edit-product.blade.php
@@ -1,4 +1,4 @@
-<form wire:submit.prevent="save" class="space-y-4">
+<form wire:submit.prevent="save" class="space-y-4 max-w-lg mx-auto p-4 sm:p-6">
     <h1 class="text-xl font-semibold">{{ __('Edit Product') }}</h1>
     <div>
         <label class="block">{{ __('Name') }}</label>

--- a/resources/views/seller/my-products.blade.php
+++ b/resources/views/seller/my-products.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="px-4 sm:px-6">
     <h1 class="text-xl font-semibold mb-4">{{ __('My Products') }}</h1>
 
     <a href="{{ route('seller.products.create') }}" class="bg-info text-dark px-4 py-2 rounded" wire:navigate>{{ __('Add Product') }}</a>

--- a/resources/views/seller/orders.blade.php
+++ b/resources/views/seller/orders.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="px-4 sm:px-6">
     <h1 class="text-xl font-semibold mb-4">{{ __('My Orders') }}</h1>
     <ul class="space-y-2">
         @foreach($orders as $order)

--- a/resources/views/seller/revenue.blade.php
+++ b/resources/views/seller/revenue.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="px-4 sm:px-6">
     <h1 class="text-xl font-semibold mb-4">{{ __('Doanh thu') }}</h1>
     <div class="mb-4">
         <select wire:model="filter" class="bg-dark border border-brand-gray p-1 rounded">

--- a/resources/views/seller/withdraw.blade.php
+++ b/resources/views/seller/withdraw.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="px-4 sm:px-6">
     <h1 class="text-xl font-semibold mb-4">{{ __('Rút Scoin') }}</h1>
     <p>{{ __('Chức năng đang được phát triển.') }}</p>
 </div>

--- a/resources/views/shop/cart.blade.php
+++ b/resources/views/shop/cart.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="px-4 sm:px-6">
     <h1 class="text-xl font-semibold mb-4">{{ __('Your Cart') }}</h1>
     <ul>
         @foreach($items as $item)

--- a/resources/views/shop/checkout.blade.php
+++ b/resources/views/shop/checkout.blade.php
@@ -1,5 +1,5 @@
 
-<div class="space-y-4">
+<div class="space-y-4 px-4 sm:px-6">
     <h1 class="text-xl font-semibold mb-4">{{ __('Checkout') }}</h1>
     <ul class="space-y-2">
         @foreach($items as $item)

--- a/resources/views/shop/index.blade.php
+++ b/resources/views/shop/index.blade.php
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+<div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 px-4 sm:px-6">
     @foreach($products as $product)
         <a
             href="{{ route('shop.show', $product) }}"

--- a/resources/views/shop/show.blade.php
+++ b/resources/views/shop/show.blade.php
@@ -1,4 +1,4 @@
-<div class="max-w-2xl mx-auto space-y-4">
+<div class="max-w-2xl mx-auto space-y-4 px-4 sm:px-6">
     <h1 class="text-2xl font-semibold">{{ $product->name }}</h1>
     <p>{{ $product->description }}</p>
     <p class="text-accent font-semibold">{{ number_format($product->price) }} Scoin</p>

--- a/resources/views/shop/thank-you.blade.php
+++ b/resources/views/shop/thank-you.blade.php
@@ -1,4 +1,4 @@
-<div class="space-y-4">
+<div class="space-y-4 px-4 sm:px-6">
     <h1 class="text-xl font-semibold text-center">{{ __('Cảm ơn bạn đã mua hàng') }}</h1>
     @if($order)
         <ul class="space-y-2">

--- a/resources/views/wallet-logs.blade.php
+++ b/resources/views/wallet-logs.blade.php
@@ -1,4 +1,4 @@
-<div>
+<div class="px-4 sm:px-6">
     <h1 class="text-xl font-semibold mb-4">{{ __('Lịch sử ví') }}</h1>
     <table class="w-full border border-brand-gray text-sm">
         <thead>


### PR DESCRIPTION
## Summary
- improve mobile responsiveness of admin sidebar and pages
- add breakpoints across seller and shop views

## Testing
- `composer` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684dbae62cfc8329ba4e0cce1cb74fe7